### PR TITLE
Use 1inch-api.aperture.finance proxy; fallback to same-pool swap when…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,4 +59,3 @@ jobs: # each workflow consists of 1+ jobs; by default, all jobs run in parallel
         env:
           INFURA_API_KEY: ${{ secrets.INFURA_API_KEY }}
           ARBITRUM_RPC_URL: ${{ secrets.ARBITRUM_RPC_URL }}
-          ONEINCH_API_KEY: ${{ secrets.ONEINCH_API_KEY }}

--- a/aggregator.ts
+++ b/aggregator.ts
@@ -20,9 +20,8 @@ import {
 import { computePoolAddress } from './pool';
 import { PositionDetails } from './position';
 
-const ApiBaseUrl = 'https://api.1inch.dev';
+const ApiBaseUrl = 'https://1inch-api.aperture.finance';
 const headers = {
-  Authorization: `Bearer ${process.env.ONEINCH_API_KEY}`,
   Accept: 'application/json',
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aperture_finance/uniswap-v3-automation-helpers",
-  "version": "1.9.2",
+  "version": "1.9.3",
   "description": "Helpers for Aperture's Uniswap V3 automation platform",
   "author": "Aperture Finance <engineering@aperture.finance>",
   "license": "MIT",


### PR DESCRIPTION
… 1inch swap data fails to generate.